### PR TITLE
Fix compatibility with NL 9.1 and later

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This bundle provides both an inbound and an outbound integration:
 | Requirements | <ul><li>License FREE edition, or Enterprise edition, or Professional with Integration & Advanced Usage</li><li>New Relic account with Infrastructures and Plugins</li></ul>|
 | Optionals | <ul><li>NeoLoad Web SaaS subscription (for option to send data from NeoLoad Web to New Relic)</li><li>New Relic account with Insights</li></ul>|
 | Bundled in NeoLoad | No |
-| Download Binaries    |  <ul><li>[latest release](https://github.com/Neotys-Labs/NewRelic/releases/latest) is only compatible with NeoLoad from version 6.7</li><li> Use this [release](https://github.com/Neotys-Labs/NewRelic/releases/tag/1.0.2) for previous NeoLoad versions</li></ul>|
+| Download Binaries    | <ul><li>[latest release](https://github.com/Neotys-Labs/NewRelic/releases/latest) is only compatible with NeoLoad from version 9.1</li><li> Use [this release 2.1.1](https://github.com/Neotys-Labs/NewRelic/releases/tag/Neotys-Labs%2FNewRelic.git-2.1.1) for NeoLoad 6.7 to 9.0</li><li> Use [this release 1.0.2](https://github.com/Neotys-Labs/NewRelic/releases/tag/1.0.2) for previous NeoLoad versions</li></ul> |
 
 
 ## Installation
@@ -201,6 +201,7 @@ See New Relic [Documentation](https://docs.newrelic.com/docs/insights/use-insigh
 * NL-NEW_RELIC_ACTION-04: Not enough delay between the two executions of the New Relic advanced action. Make sure to have at least 60 seconds pacing on the Actions container.  
 
 ## ChangeLog
+* Version 3.0.0 (January 10, 2022): Update version of NeoLoad DataExchange API client that is now compatible with java modules. Bump a dependency.
 * Version 2.1.0 (April 15, 2019): 
     * The number of default counters to return has been decreased.
     * Bug fix: The Advanced Action can now retrieve all the existing metric names.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.neotys.NewRelic</groupId>
     <artifactId>NewRelicAction</artifactId>
     <name>NewRelicAction</name>
-    <version>2.1.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <properties>
         <swagger-core-version>1.5.12</swagger-core-version>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.neotys.rest</groupId>
             <artifactId>neotys-rest-api-dataexchange-client-olingo</artifactId>
-            <version>1.0.4</version>
+            <version>1.1.1</version>
             <!-- already in NeoLoad: can cause conflicts -->
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.1</version>
+            <version>4.5.13</version>
             <!-- already in NeoLoad: can cause conflicts -->
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/com/neotys/newrelic/NewRelicActionEngine.java
+++ b/src/main/java/com/neotys/newrelic/NewRelicActionEngine.java
@@ -12,7 +12,7 @@ import com.neotys.newrelic.rest.NewRelicApplicationHost;
 import com.neotys.newrelic.rest.NewRelicMetricData;
 import com.neotys.newrelic.rest.NewRelicRestClient;
 import com.neotys.rest.dataexchange.client.DataExchangeAPIClient;
-import com.neotys.rest.dataexchange.client.DataExchangeAPIClientFactory;
+import com.neotys.rest.dataexchange.client.olingo.DataExchangeAPIClientFactory;
 import com.neotys.rest.dataexchange.model.ContextBuilder;
 
 import java.util.List;


### PR DESCRIPTION
This commit fixed LOAD-27930 [NLG] Custom actions using the data exchange API no longer work
This is a breaking change that 

+ bump dependency for apache httpclient
Build passed on jenkins-public